### PR TITLE
Fix README to use correct graphite host environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ to the outside world.
 The following enviromental varaible are supported by this image.
 
 - **GRAPHITE_PORT_2003_TCP_PORT** (default: 2003)
-- **GRAPHITE_PORT_2003_TCP_ADD**  (default: localhost)
+- **GRAPHITE_PORT_2003_TCP_ADDR**  (default: localhost)
 - **GRAPHITE_GLOBAL_PREFIX**      (default: stats) 
 - **GRAPHITE_LEGACY_NAMESPACE**   (default: true) 
 - **STATSD_PORT**                 (default: 8125)
@@ -32,7 +32,7 @@ The following enviromental varaible are supported by this image.
 Example to run the docker instance:
 
 ```
-sudo docker run -e GRAPHITE_HOST=127.0.0.1 -e STATSD_DUMP_MSG=true -p 8125:8125/udp -p 8126:8126/tcp -d jaconel/statsd
+sudo docker run -e GRAPHITE_PORT_2003_TCP_ADDR=127.0.0.1 -e STATSD_DUMP_MSG=true -p 8125:8125/udp -p 8126:8126/tcp -d jaconel/statsd
 ```
 
 This image is available in the docker registry at jaconel/statsd:


### PR DESCRIPTION
The current documentation lists "GRAPHITE_PORT_2003_TCP_ADD" as the environment variable used to configure the graphite host, however the actual environment variable used in config.js is "GRAPHITE_PORT_2003_TCP_ADDR" (with an R on the end).

The example run command also gives an incorrect environment variable of "GRAPHITE_HOST" instead of "GRAPHITE_PORT_2003_TCP_ADDR".

This pull request fixes both of these.

Hope that helps!